### PR TITLE
Fix Gavel image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gavel—HTTP validator
 
-![Gavel logo](https://raw.github.com/apiaryio/gavel/master/img/gavel.png?login=netmilk&token=73e03867f59ec1870842429ca2f7e8b9)
+![Gavel logo](https://raw.github.com/apiaryio/gavel/master/img/gavel.png)
 
 ## What is Gavel? 
 


### PR DESCRIPTION
Trivial change, but the GET params break the image link for unauthenticated users.
