### PR TITLE
Provides valid JSON for "body_json_example" feature

### DIFF
--- a/features/expectations/body_json_example.feature
+++ b/features/expectations/body_json_example.feature
@@ -71,7 +71,6 @@ Feature: Body - JSON example
       ],
       "string": "Foo bar",
       "boolean": false
-
     }
     """
     Then Gavel will NOT set any errors for "body"
@@ -89,7 +88,7 @@ Feature: Body - JSON example
       "array": [
         1
       ],
-      "string": "Foo bar",
+      "string": "Foo bar"
     }
     """
     Then Gavel will set some error for "body"


### PR DESCRIPTION
Fixes an invalid JSON example included in the `body_json_example` feature suit:

https://github.com/apiaryio/gavel-spec/blob/f8224f62cde6af7f0a544bf03188778c677d225d/features/expectations/body_json_example.feature#L80-L96

The feature suit expects Gavel to throw because of the missing array member in the real body. While Gavel does throw, that happens not because of the missing array member, but because an attempt to parse the given JSON example fails (since it's invalid JSON), and body media types become the following:

```
real: text/plain
expected: application/json
```

Such combination of body media types has no corresponding validator in Gavel, and thus it throws an explicit error about this:

https://github.com/apiaryio/gavel.js/blob/efe1eb093d4b4433d924995088cb616100a53373/lib/mixins/validatable-http-message.js#L311-L317

Since Gavel currently stores internal exceptions and public validation results under the same `results` key, the spec assumes the thrown error is the validation error, while it's a parsing error. This is a good example why https://github.com/apiaryio/gavel.js/issues/163 may be a sensible improvement in the future.
