### PR TITLE
Removes missing array member due to non-working feature

### DIFF
--- a/features/expectations/body_json_example.feature
+++ b/features/expectations/body_json_example.feature
@@ -76,24 +76,6 @@ Feature: Body - JSON example
     Then Gavel will NOT set any errors for "body"
     And Request or Response is valid
 
-  Scenario: Array member is missing in real JSON body
-    When real HTTP body is following:
-    """
-    {
-      "object": {
-        "a": "bau bau",
-        "c": "boo boo",
-        "e": "mrau mrau"
-      },
-      "array": [
-        1
-      ],
-      "string": "Foo bar"
-    }
-    """
-    Then Gavel will set some error for "body"
-    And Request or Response is NOT valid
-
   Scenario: Extra array member in real JSON body
     When real HTTP body is following:
     """


### PR DESCRIPTION
Removes missing array member scenario because it appears to have never worked in `gavel.js`.

The scenario and functionality itself is to be reverted in #40, after respective changes on Gavel.js side.