### PR TITLE
Adds "inValid" property in the validation results

### DIFF
--- a/features/javascript/request_async_api.feature
+++ b/features/javascript/request_async_api.feature
@@ -73,6 +73,7 @@ Feature: Request Async API
     Then "validationResult" variable will contain:
     """
     { version: "2",
+      isValid: true,
       headers:
        { results: [],
          realType: 'application/vnd.apiary.http-headers+json',

--- a/features/javascript/request_sync_api.feature
+++ b/features/javascript/request_sync_api.feature
@@ -66,6 +66,7 @@ Feature: request Sync API
     Then it will return:
     """
     { version: "2",
+      isValid: true,
       headers:
        { results: [],
          realType: 'application/vnd.apiary.http-headers+json',

--- a/features/javascript/response_async_api.feature
+++ b/features/javascript/response_async_api.feature
@@ -78,6 +78,7 @@ Feature: Response Async API
     Then "validationResult" variable will contain:
     """
     { version: "2",
+      isValid: true,
       headers:
        { results: [],
          realType: 'application/vnd.apiary.http-headers+json',

--- a/features/javascript/response_sync_api.feature
+++ b/features/javascript/response_sync_api.feature
@@ -71,22 +71,23 @@ Feature: Response Sync API
     Then it will return:
     """
     { version: "2",
-  headers:
-   { results: [],
-     realType: 'application/vnd.apiary.http-headers+json',
-     expectedType: 'application/vnd.apiary.http-headers+json',
-     validator: 'HeadersJsonExample',
-     rawData: { length: 0 } },
-  body:
-   { results: [],
-     realType: 'application/json',
-     expectedType: 'application/json',
-     validator: 'JsonExample',
-     rawData: { length: 0 } },
-  statusCode:
-   { realType: 'text/vnd.apiary.status-code',
-     expectedType: 'text/vnd.apiary.status-code',
-     validator: 'TextDiff',
-     rawData: '',
-     results: [] } }
+      isValid: true,
+      headers:
+      { results: [],
+        realType: 'application/vnd.apiary.http-headers+json',
+        expectedType: 'application/vnd.apiary.http-headers+json',
+        validator: 'HeadersJsonExample',
+        rawData: { length: 0 } },
+      body:
+      { results: [],
+        realType: 'application/json',
+        expectedType: 'application/json',
+        validator: 'JsonExample',
+        rawData: { length: 0 } },
+      statusCode:
+      { realType: 'text/vnd.apiary.status-code',
+        expectedType: 'text/vnd.apiary.status-code',
+        validator: 'TextDiff',
+        rawData: '',
+        results: [] } }
     """


### PR DESCRIPTION
- Providing specification part for https://github.com/apiaryio/gavel.js/issues/166

## Changelog

- Validation result now contains `isValid` field that describes whether the given HTTP messages validation has concluded them as matching.
- Removes references to `gavel.isValid()` separate method (see motivation in the issue mentioned above).