### PR TITLE
fix: tags feature definitions with "@javascript" tag

### DIFF
--- a/features/expectations/body_text_example.feature
+++ b/features/expectations/body_text_example.feature
@@ -3,49 +3,49 @@ Feature: Body - text example
 
   Background:
     Given you define expected HTTP body using the following "textual example":
-    """
-    One, two, three, four.
-    Orange, strawberry, banana?
-    Dog, cat, mouse!
-    """
+      """
+      One, two, three, four.
+      Orange, strawberry, banana?
+      Dog, cat, mouse!
+      """
 
   Scenario: Line is missing in real payload body
     When real HTTP body is following:
-    """
-    One, two, three, four.
-    Orange, strawberry, banana?
-    """
+      """
+      One, two, three, four.
+      Orange, strawberry, banana?
+      """
     Then field "body" is NOT valid
     And Request or Response is NOT valid
 
   Scenario: Extra line in real payload textual body
     When real HTTP body is following:
-    """
-    Red, green, blue...
-    One, two, three, four.
-    Orange, strawberry, banana?
-    Dog, cat, mouse!
-    """
+      """
+      Red, green, blue...
+      One, two, three, four.
+      Orange, strawberry, banana?
+      Dog, cat, mouse!
+      """
     Then field "body" is NOT valid
     And Request or Response is NOT valid
 
   Scenario: Line is changed in real textual body
     When real HTTP body is following:
-    """
-    Red, green, blue...
-    Orange, strawberry, banana?
-    Dog, cat, mouse!
-    """
+      """
+      Red, green, blue...
+      Orange, strawberry, banana?
+      Dog, cat, mouse!
+      """
     Then field "body" is NOT valid
     And Request or Response is NOT valid
 
   Scenario: Text in body equals defined example
     When real HTTP body is following:
-    """
-    One, two, three, four.
-    Orange, strawberry, banana?
-    Dog, cat, mouse!
-    """
+      """
+      One, two, three, four.
+      Orange, strawberry, banana?
+      Dog, cat, mouse!
+      """
     Then field "body" is valid
     And Request or Response is valid
 

--- a/features/expectations/headers.feature
+++ b/features/expectations/headers.feature
@@ -1,59 +1,59 @@
-@javascript
+@javascript @stable
 Feature: Headers
   http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
 
   Background:
     Given you expect the following HTTP headers:
-    """
-    Content-Type: text/plain
-    Date: Fri, 31 Dec 1999 23:59:59 GMT
-    Location: /here
-    ETag: 68b329da9893e34099c7d8ad5cb9c940
-    """
+      """
+      Content-Type: text/plain
+      Date: Fri, 31 Dec 1999 23:59:59 GMT
+      Location: /here
+      ETag: 68b329da9893e34099c7d8ad5cb9c940
+      """
 
   @stable
   Scenario: Header is missing in real payload
     When real HTTP headers are following:
-    """
-    Content-Type: text/plain
-    """
+      """
+      Content-Type: text/plain
+      """
     Then field "headers" is NOT valid
     And Request or Response is NOT valid
 
   @stable
   Scenario: Extra real header in real payload
     When real HTTP headers are following:
-    """
-    Content-Type: text/plain
-    Content-Length: 1354
-    Date: Fri, 31 Dec 1999 23:59:59 GMT
-    Location: /here
-    ETag: 68b329da9893e34099c7d8ad5cb9c940
-    """
+      """
+      Content-Type: text/plain
+      Content-Length: 1354
+      Date: Fri, 31 Dec 1999 23:59:59 GMT
+      Location: /here
+      ETag: 68b329da9893e34099c7d8ad5cb9c940
+      """
     Then field "headers" is valid
     And Request or Response is valid
 
   @stable
   Scenario: Content nogotiation significant header value is different in real payload
     When real HTTP headers are following:
-    """
-    Content-Type: application/json
-    Date: Fri, 31 Dec 1999 23:59:59 GMT
-    Location: /here
-    ETag: 68b329da9893e34099c7d8ad5cb9c940
-    """
+      """
+      Content-Type: application/json
+      Date: Fri, 31 Dec 1999 23:59:59 GMT
+      Location: /here
+      ETag: 68b329da9893e34099c7d8ad5cb9c940
+      """
     Then field "headers" is NOT valid
     And Request or Response is NOT valid
 
   @stable
   Scenario: Content negotiation not significant header value is different in real payload
     When real HTTP headers are following:
-    """
-    Content-Type: text/plain
-    Date: Fri, 13 Dec 3000 23:59:59 GMT
-    Location: /there
-    ETag: something-completely-different
-    """
+      """
+      Content-Type: text/plain
+      Date: Fri, 13 Dec 3000 23:59:59 GMT
+      Location: /there
+      ETag: something-completely-different
+      """
     Then field "headers" is valid
     And Request or Response is valid
 

--- a/features/expectations/method.feature
+++ b/features/expectations/method.feature
@@ -1,11 +1,11 @@
-@stable
+@javascript @stable
 Feature: Method
 
   Background:
     Given you expect HTTP message method "POST"
 
   Scenario: HTTP message method match
-    When real method is "POST"
+    When real HTTP message method is "POST"
     Then field "method" is valid
     And Request or Response is valid
 

--- a/features/expectations/status_code.feature
+++ b/features/expectations/status_code.feature
@@ -1,4 +1,4 @@
-@stable
+@javascript @stable
 Feature: Status code
 
   Background:


### PR DESCRIPTION
Feature definitions that are not tagged as `@javascript` are not being run in `gavel.js`.

These changes tag Gavel features with `@javascript` tag so they are tested in Gavel.js. This also requires changes from `gavel` package, because due to some feature suites were not tested, it had incorrect implementation of Cucumber steps. Pull request in Gavel.js will follow.