### PR TITLE
Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,11 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    default_labels:
+      - "dependencies"
+    commit_message:
+      prefix: "fix"
+      prefix_development: "chore"
+      include_scope: true


### PR DESCRIPTION
Explicit configuration makes things explicit 😄 We've experienced inconsistent dependabot behavior if it was left up to them to detect, so forcing what we want by an explicit config.